### PR TITLE
feat: add upload button for custom stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,8 @@ tr:hover td{ background:#0e141c; }
 <header>
   <h1>WZ Stats Viewer</h1>
   <span class="badge" id="sourceBadge">Source: local ./stats</span>
+  <input type="file" id="uploadInput" accept="application/json" style="display:none" />
+  <label for="uploadInput" class="btn" id="uploadBtn">Upload</label>
 </header>
 
 <div class="container">
@@ -126,6 +128,7 @@ tr:hover td{ background:#0e141c; }
 
 
 (async function(){
+  const UPLOAD_KEY = 'wzStatsUploadData';
   async function loadJSON(path){
     try{
       const res = await fetch(path);
@@ -136,9 +139,22 @@ tr:hover td{ background:#0e141c; }
       return [];
     }
   }
-  const structures = await loadJSON("stats/structure.json");
-  const weapons = await loadJSON("stats/weapons.json");
-  const BOOTSTRAP = { meta:{source:"local", filename:null}, base:"stats", structures, weapons, files:{structures:"stats/structure.json", weapons:"stats/weapons.json"}, baseline:{ base:"stats", structures, weapons, files:{structures:"stats/structure.json", weapons:"stats/weapons.json"} } };
+  async function loadBootstrap(){
+    const stored = localStorage.getItem(UPLOAD_KEY);
+    if (stored){
+      try { return JSON.parse(stored); }
+      catch(e){ localStorage.removeItem(UPLOAD_KEY); }
+    }
+    const structures = await loadJSON("stats/structure.json");
+    const weapons = await loadJSON("stats/weapons.json");
+    return { meta:{source:"local", filename:null}, base:"stats", structures, weapons, files:{structures:"stats/structure.json", weapons:"stats/weapons.json"}, baseline:{ base:"stats", structures, weapons, files:{structures:"stats/structure.json", weapons:"stats/weapons.json"} } };
+  }
+  const BOOTSTRAP = await loadBootstrap();
+  const sourceBadge = document.getElementById('sourceBadge');
+  if (sourceBadge && BOOTSTRAP && BOOTSTRAP.meta){
+    const name = BOOTSTRAP.meta.filename ? ` ${BOOTSTRAP.meta.filename}` : ' ./stats';
+    sourceBadge.textContent = `Source: ${BOOTSTRAP.meta.source}${name}`;
+  }
   function escapeHtml(s){ return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/\"/g,'&quot;').replace(/'/g,'&#39;'); }
   const isNumber = (v) => typeof v === 'number' || (typeof v === 'string' && v.trim() !== '' && !isNaN(Number(v)));
   const toCell = (v) => (v===null||v===undefined) ? '' : (typeof v === 'object' ? JSON.stringify(v) : String(v));
@@ -430,6 +446,32 @@ tr:hover td{ background:#0e141c; }
   document.querySelectorAll('.tabbar .tab').forEach(el => el.addEventListener('click', () => switchTab(el.dataset.tab)));
   searchInput.addEventListener('input', renderBody);
   clearBtn.addEventListener('click', () => { searchInput.value=''; renderBody(); });
+
+  const uploadInput = document.getElementById('uploadInput');
+  if (uploadInput){
+    uploadInput.addEventListener('change', async () => {
+      const f = uploadInput.files && uploadInput.files[0];
+      if (!f) return;
+      try{
+        const text = await f.text();
+        const data = JSON.parse(text);
+        const baseStructs = await loadJSON('stats/structure.json');
+        const baseWeapons = await loadJSON('stats/weapons.json');
+        const store = {
+          meta:{source:'upload', filename:f.name},
+          base:'upload',
+          structures:data.structures || [],
+          weapons:data.weapons || [],
+          files:{},
+          baseline:{ base:'stats', structures:baseStructs, weapons:baseWeapons, files:{structures:'stats/structure.json', weapons:'stats/weapons.json'} }
+        };
+        localStorage.setItem(UPLOAD_KEY, JSON.stringify(store));
+        location.reload();
+      }catch(e){
+        alert('Failed to load file: ' + e.message);
+      }
+    });
+  }
 
   switchTab('structures');
 })();


### PR DESCRIPTION
## Summary
- add Upload control to header for loading custom stats
- support reading uploaded JSON and storing data for diff display

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bce277d32083338acec437e9fb6472