### PR TITLE
Allow uploading any file type

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@ tr:hover td{ background:#0e141c; }
 <header>
   <h1>WZ Stats Viewer</h1>
   <span class="badge" id="sourceBadge">Source: local ./stats</span>
-  <input type="file" id="uploadInput" accept="application/json" style="display:none" />
+  <input type="file" id="uploadInput" style="display:none" />
   <label for="uploadInput" class="btn" id="uploadBtn">Upload</label>
 </header>
 


### PR DESCRIPTION
## Summary
- Remove JSON-only restriction from file upload input so any file type can be selected

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bce8e9dbe483339ff7b8445db11091