### PR TITLE
Strip BOM from uploaded JSON to avoid parse error

### DIFF
--- a/index.html
+++ b/index.html
@@ -453,7 +453,8 @@ tr:hover td{ background:#0e141c; }
       const f = uploadInput.files && uploadInput.files[0];
       if (!f) return;
       try{
-        const text = await f.text();
+        let text = await f.text();
+        if (text.charCodeAt(0) === 0xFEFF) text = text.slice(1);
         const data = JSON.parse(text);
         const baseStructs = await loadJSON('stats/structure.json');
         const baseWeapons = await loadJSON('stats/weapons.json');


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM from uploaded files before JSON parsing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bceb532804833389b5db7a61810614