### PR TITLE
fix: ensure filter chip buttons show inactive color

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@ input[type="text"]{ background:#0e141c; color:var(--fg); border:1px solid var(--
 button,.btn{ background:var(--accent); border:none; color:#021423; padding:10px 14px; border-radius:10px; cursor:pointer; font-weight:600; }
 button.secondary{ background:#1f2a36; color:var(--fg); border:1px solid var(--border); }
 .secondary.active{ background:var(--accent); color:#04111e; border-color:transparent; }
+button.filter-chip{ background:#1f2a36; color:var(--fg); border:1px solid var(--border); }
+button.filter-chip.active{ background:var(--accent); color:#04111e; border-color:transparent; }
 button:disabled{ opacity:.5; cursor:not-allowed; }
 .tabbar{ display:flex; gap:8px; margin:12px 0; }
 .tab{ padding:8px 12px; border-radius:999px; border:1px solid var(--border); cursor:pointer; }


### PR DESCRIPTION
## Summary
- style filter chip buttons to use neutral colors when not active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcfc99c7448333920ce959f56d05ba