### PR TITLE
Expose canvas renderer for PIE previews

### DIFF
--- a/js/piePreview-init.js
+++ b/js/piePreview-init.js
@@ -3,12 +3,14 @@
 // Some parts of the app import { showPie } from './piePreview.js'.
 // Others may call window.WZPIE.showPie(...). We support both.
 
-import { showPie, configurePieBase } from './piePreview.js';
+import { showPie, configurePieBase, renderPieIntoCanvas } from './piePreview.js';
 
 // Expose on a namespaced global for inline scripts (optional)
 window.WZPIE = window.WZPIE || {};
 window.WZPIE.showPie = showPie;
 window.WZPIE.configurePieBase = configurePieBase;
+// expose a helper used by inline scripts to render directly into a canvas
+window.WZPIE.renderToCanvas = renderPieIntoCanvas;
 
 // If the page wants to auto-init a base path, it may provide
 // <meta name="pie-base" content="/assets/">; we apply it here.


### PR DESCRIPTION
## Summary
- expose `WZPIE.renderToCanvas` helper so thumbnail code can render PIE models

## Testing
- `node --check js/piePreview-init.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcffe3dcd88333b43f4955a34cb15a