### PR TITLE
Fix PIE preview rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,12 +50,8 @@ tr:hover td{ background:#0e141c; }
 </head>
 <body>
 
-<script type="module">
-  import "./js/three.module.js";
-  import "./js/pie.js";
-  import "./js/piePreview.js";
-  import "./js/piePreview-init.js";
-</script>
+<!-- Loader for PIE previews and Three.js helpers -->
+
 
 <header>
   <h1>WZ Stats Viewer</h1>
@@ -100,15 +96,27 @@ tr:hover td{ background:#0e141c; }
     </div>
   </div>
 </div>
-<script>
+<script type="module">
+  import "./js/three.module.js";
+  import "./js/pie.js";
+  import "./js/piePreview.js";
+  import "./js/piePreview-init.js";
+  import "./js/pie-loader.js";
+
   const pieOverlay = null;
-  function resolvePieUrl(filename){
+  async function resolvePieUrl(filename){
     const roots = ['components','structs','structures','effects','models','base'];
-    for (const r of roots){ return `${r}/${filename}`; }
+    for (const r of roots){
+      const url = `${r}/${filename}`;
+      try {
+        const res = await fetch(url, { method: 'HEAD' });
+        if (res.ok) return url;
+      } catch (_) {}
+    }
     return filename;
   }
   async function renderPieToCanvas(canvas, pieFile){
-    const url = resolvePieUrl(pieFile);
+    const url = await resolvePieUrl(pieFile);
     try {
       if (window.WZPIE && typeof WZPIE.renderToCanvas === 'function') {
         await WZPIE.renderToCanvas(canvas, url, { background:'#0a0f14' });

--- a/js/pie-loader.js
+++ b/js/pie-loader.js
@@ -1,0 +1,78 @@
+import * as THREE from './three.module.js';
+
+function parsePieGeometry(text){
+  const lines = text.split(/\r?\n/).map(l=>l.trim()).filter(l=>l && !l.startsWith('#'));
+  const vertices = [];
+  const faces = [];
+  let i=0;
+  while(i<lines.length){
+    const line = lines[i];
+    if(line.startsWith('POINTS')){
+      const count = parseInt(line.split(/\s+/)[1],10);
+      for(let j=0;j<count;j++){
+        i++;
+        const parts = lines[i].split(/\s+/).map(Number);
+        vertices.push(parts);
+      }
+    } else if(line.startsWith('POLYGONS')){
+      const count = parseInt(line.split(/\s+/)[1],10);
+      for(let j=0;j<count;j++){
+        i++;
+        const parts = lines[i].split(/\s+/).map(Number);
+        const vc = parts[1];
+        const idx = parts.slice(2,2+vc);
+        for(let k=1;k<vc-1;k++){
+          faces.push([idx[0], idx[k], idx[k+1]]);
+        }
+      }
+    }
+    i++;
+  }
+  const positions = [];
+  for(const f of faces){
+    for(const vi of f){
+      const v = vertices[vi];
+      positions.push(v[0], v[1], v[2]);
+    }
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.Float32BufferAttribute(positions,3));
+  geo.computeVertexNormals();
+  return geo;
+}
+
+async function loadPieGeometry(url){
+  const res = await fetch(url);
+  if(!res.ok) throw new Error('Failed to load PIE '+url);
+  const text = await res.text();
+  return parsePieGeometry(text);
+}
+
+async function render(canvas, url, options={}){
+  const geometry = await loadPieGeometry(url);
+  const dpr = window.devicePixelRatio || 1;
+  const w = canvas.clientWidth || 96;
+  const h = canvas.clientHeight || 96;
+  const renderer = new THREE.WebGLRenderer({ canvas, antialias:true, alpha:true });
+  renderer.setSize(w*dpr, h*dpr, false);
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(45, w/h, 0.1, 1000);
+  camera.position.set(0,0,100);
+  scene.add(new THREE.HemisphereLight(0xffffff,0x444444,1));
+  const material = new THREE.MeshStandardMaterial({ color:0xdddddd });
+  const mesh = new THREE.Mesh(geometry, material);
+  geometry.computeBoundingSphere();
+  if(geometry.boundingSphere){
+    const s = 40/geometry.boundingSphere.radius;
+    mesh.scale.setScalar(s);
+    mesh.position.set(
+      -geometry.boundingSphere.center.x*s,
+      -geometry.boundingSphere.center.y*s,
+      -geometry.boundingSphere.center.z*s
+    );
+  }
+  scene.add(mesh);
+  renderer.render(scene, camera);
+}
+
+window.PIELoader = { render };


### PR DESCRIPTION
## Summary
- load PIE preview scripts as ES module and resolve asset paths before rendering
- add simple PIELoader based on THREE.js to draw PIE models on canvases

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0203cfe883338de4a3cd0e570f0d