### PR TITLE
Ensure PIE assets are looked up in lowercase

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@ tr:hover td{ background:#0e141c; }
 
   const pieOverlay = null;
   async function resolvePieUrl(filename){
+    filename = String(filename || '').toLowerCase();
     // Search order for PIE assets. Structures now live in /structs, while
     // weapon, body and propulsion models are under their respective
     // subdirectories inside /components.


### PR DESCRIPTION
## Summary
- Normalize filenames to lowercase when resolving PIE asset URLs so search only uses lower-case `.pie` paths.

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0a492d4c8333a9c245ad1b2478cc