### PR TITLE
Expand PIE preview and add rotation

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@ tr:hover td{ background:#0e141c; }
 
 /* PIE preview popup */
 .pie-link{ cursor:pointer; color:var(--accent); }
-#piePopup{ position:fixed; top:50%; left:50%; width:200px; height:200px; margin:-100px 0 0 -100px; background:#0a0f14; border:1px solid var(--border); border-radius:8px; z-index:100; }
+#piePopup{ position:fixed; top:5%; left:5%; width:90vw; height:90vh; margin:0; background:#0a0f14; border:1px solid var(--border); border-radius:8px; z-index:100; }
 #piePopup.hidden{ display:none; }
 #piePopup canvas{ width:100%; height:100%; display:block; }
 #piePopup button{ position:absolute; top:4px; right:4px; background:none; border:none; color:var(--fg); cursor:pointer; }

--- a/js/pie-loader.js
+++ b/js/pie-loader.js
@@ -116,7 +116,12 @@ async function render(canvas, url, options={}){
     );
   }
   scene.add(mesh);
-  renderer.render(scene, camera);
+  function animate(){
+    requestAnimationFrame(animate);
+    mesh.rotation.y += 0.005;
+    renderer.render(scene, camera);
+  }
+  animate();
 }
 
 window.PIELoader = { render };


### PR DESCRIPTION
## Summary
- Expand PIE preview popup to fill 90% of the viewport
- Animate PIE models with a slow continuous rotation

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `apt-get update` *(fails: 403 Forbidden [IP: 172.30.2.35 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68bd1f0c13488333b1bf6877399060d9