### PR TITLE
Add configurable zoom for PIE file rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@ tr:hover td{ background:#0e141c; }
     const url = await resolvePieUrl(pieFile);
     try {
       if (window.WZPIE && typeof WZPIE.renderToCanvas === 'function') {
-        await WZPIE.renderToCanvas(canvas, url, { background:'#0a0f14' });
+        await WZPIE.renderToCanvas(canvas, url, { background:'#0a0f14', zoom:0.5 });
         return true;
       }
       if (window.renderPieModel && typeof window.renderPieModel === 'function') {
@@ -156,7 +156,7 @@ tr:hover td{ background:#0e141c; }
         return true;
       }
       if (window.PIELoader && typeof window.PIELoader.render === 'function') {
-        await window.PIELoader.render(canvas, url);
+        await window.PIELoader.render(canvas, url, { zoom:0.5 });
         return true;
       }
     } catch(e){ console.error('PIE render error:', e); }

--- a/js/pie-loader.js
+++ b/js/pie-loader.js
@@ -107,7 +107,8 @@ async function render(canvas, url, options={}){
   const mesh = new THREE.Mesh(geometry, material);
   geometry.computeBoundingSphere();
   if(geometry.boundingSphere){
-    const s = 40/geometry.boundingSphere.radius;
+    const zoom = (typeof options.zoom === 'number') ? options.zoom : 1;
+    const s = 40 * zoom / geometry.boundingSphere.radius;
     mesh.scale.setScalar(s);
     mesh.position.set(
       -geometry.boundingSphere.center.x*s,


### PR DESCRIPTION
## Summary
- allow PIE loader to accept a `zoom` option
- render popup pies at half scale for easier viewing

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2172819083338a52623e64859cd5