### PR TITLE
Tilt preview camera for top view

### DIFF
--- a/js/pie-loader.js
+++ b/js/pie-loader.js
@@ -89,7 +89,8 @@ async function render(canvas, url, options={}){
   renderer.setSize(w*dpr, h*dpr, false);
   const scene = new THREE.Scene();
   const camera = new THREE.PerspectiveCamera(45, w/h, 0.1, 1000);
-  camera.position.set(0,0,100);
+  camera.position.set(0,70,70);
+  camera.lookAt(0,0,0);
   scene.add(new THREE.HemisphereLight(0xffffff,0x444444,1));
   const materialOptions = { color:0xdddddd };
   if(geometry.userData.texture){

--- a/js/pie-mini-viewer.js
+++ b/js/pie-mini-viewer.js
@@ -13,7 +13,8 @@ export async function renderPieThumbnail(container, fileOrText) {
 
   const scene = new THREE.Scene();
   const camera = new THREE.PerspectiveCamera(50, w/h, 0.1, 100);
-  camera.position.set(0, 0.6, 2.0);
+  camera.position.set(0, 1.5, 1.5);
+  camera.lookAt(0, 0, 0);
 
   const hemi = new THREE.HemisphereLight(0xffffff, 0x404040, 0.9);
   scene.add(hemi);


### PR DESCRIPTION
## Summary
- tilt PIE preview cameras to a 45° top angle for both main and thumbnail viewers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd232312ac8333ae943795eb97960d