### PR TITLE
fix: resolve weapon PIE paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,9 +135,13 @@ tr:hover td{ background:#0e141c; }
     // Search order for PIE assets. Structures now live in /structs, while
     // weapon, body and propulsion models are under their respective
     // subdirectories inside /components.
+    // Weapon models live under /components/weapons, while structures
+    // are found in /structs. Check the weapon path first so that the
+    // Weapons tab does not try to load files from the structures
+    // directory.
     const roots = [
-      'structs',
       'components/weapons',
+      'structs',
       'components/bodies',
       'components/prop',
       'components',


### PR DESCRIPTION
## Summary
- resolve weapon PIE assets under components/weapons instead of structs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2bcf8e2c83339cbb072f658f2beb