### PR TITLE
fix: load PIE assets on case-sensitive systems

### DIFF
--- a/js/pie.js
+++ b/js/pie.js
@@ -20,7 +20,9 @@ export function setPiesBase(base) {
  */
 export function resolveTextureUrl(relPath) {
   if (!relPath) return null;
-  var s = String(relPath);
+  // Coerce to string and normalise casing so PIE data with upper-case paths
+  // can reference lower-case files on case-sensitive file systems.
+  var s = String(relPath).toLowerCase();
   // Normalise backslashes and leading ./
   s = s.replace(/\\/g, "/").replace(/^\.\/+/, "");
   // Avoid accidental double slashes when joining


### PR DESCRIPTION
## Summary
- normalize file paths when resolving PIE assets to ensure case-insensitive loading

## Testing
- `node --check js/pie.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd308da5648333a0dddbf7077a19bd