### PR TITLE
Default PIE asset path to /pies

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,37 +125,20 @@ tr:hover td{ background:#0e141c; }
       piePopup.removeAttribute('aria-busy');
     }
   }
-  async function resolvePieUrl(filename){
-    if (Array.isArray(filename)) {
-      const out = [];
-      for (const f of filename) out.push(await resolvePieUrl(f));
-      return out;
-    }
-    filename = String(filename || '').toLowerCase();
-    // Search order for PIE assets. Structures now live in /structs, while
-    // weapon, body and propulsion models are under their respective
-    // subdirectories inside /components.
-    // Weapon models live under /components/weapons, while structures
-    // are found in /structs. Check the weapon path first so that the
-    // Weapons tab does not try to load files from the structures
-    // directory.
-    const roots = [
-      'components/weapons',
-      'structs',
-      'components/bodies',
-      'components/prop',
-      'components',
-      'structures'
-    ];
-    for (const r of roots){
-      const url = `${r}/${filename}`;
+    async function resolvePieUrl(filename){
+      if (Array.isArray(filename)) {
+        const out = [];
+        for (const f of filename) out.push(await resolvePieUrl(f));
+        return out;
+      }
+      filename = String(filename || '').toLowerCase();
+      const url = `pies/${filename}`;
       try {
         const res = await fetch(url, { method: 'HEAD' });
         if (res.ok) return url;
       } catch (_) {}
+      return filename;
     }
-    return filename;
-  }
   async function renderPieToCanvas(canvas, pieFile){
     const files = Array.isArray(pieFile) ? pieFile : [pieFile];
     const url = await resolvePieUrl(files);

--- a/js/piePreview-init.js
+++ b/js/piePreview-init.js
@@ -16,5 +16,11 @@ window.WZPIE.renderToCanvas = renderPieIntoCanvas;
 // <meta name="pie-base" content="/assets/">; we apply it here.
 try {
   const meta = document.querySelector('meta[name="pie-base"][content]');
-  if (meta && meta.content) configurePieBase(meta.content);
-} catch (_) {}
+  if (meta && meta.content) {
+    configurePieBase(meta.content);
+  } else {
+    configurePieBase('/pies');
+  }
+} catch (_) {
+  configurePieBase('/pies');
+}


### PR DESCRIPTION
## Summary
- Default PIE base path to `/pies` when no `pie-base` meta tag is present
- Simplify PIE file resolution to look in `/pies` by default

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3562bfe48333816241686b704f1e