### PR TITLE
Use relative base path for PIE resources

### DIFF
--- a/js/piePreview-init.js
+++ b/js/piePreview-init.js
@@ -14,13 +14,14 @@ window.WZPIE.renderToCanvas = renderPieIntoCanvas;
 
 // If the page wants to auto-init a base path, it may provide
 // <meta name="pie-base" content="/assets/">; we apply it here.
+// Defaults to the current directory.
 try {
   const meta = document.querySelector('meta[name="pie-base"][content]');
   if (meta && meta.content) {
     configurePieBase(meta.content);
   } else {
-    configurePieBase('/pies');
+    configurePieBase('.');
   }
 } catch (_) {
-  configurePieBase('/pies');
+  configurePieBase('.');
 }


### PR DESCRIPTION
## Summary
- Default PIE resource base path to current directory instead of `/pies`

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bd36d0b4808333b0ca762deb133538