### PR TITLE
Handle PIE filenames missing leading zeros

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,17 @@ tr:hover td{ background:#0e141c; }
         const res = await fetch(url, { method: 'HEAD' });
         if (res.ok) return url;
       } catch (_) {}
+      // some stats reference PIE files with a leading zero that is
+      // not present in the assets directory. Try stripping leading
+      // zeroes and look for a matching file.
+      const alt = filename.replace(/^0+/, '');
+      if (alt !== filename) {
+        const altUrl = `pies/${alt}`;
+        try {
+          const res2 = await fetch(altUrl, { method: 'HEAD' });
+          if (res2.ok) return altUrl;
+        } catch (_) {}
+      }
       return filename;
     }
   async function renderPieToCanvas(canvas, pieFile){
@@ -156,9 +167,14 @@ tr:hover td{ background:#0e141c; }
         return true;
       }
     } catch(e){ console.error('PIE render error:', e); }
-    const ctx = canvas.getContext('2d'); ctx.fillStyle = '#0a0f14'; ctx.fillRect(0,0,canvas.width,canvas.height);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return false;
+    ctx.fillStyle = '#0a0f14';
+    ctx.fillRect(0,0,canvas.width,canvas.height);
     const label = Array.isArray(files) ? String(files[0]) : String(files);
-    ctx.fillStyle = '#9fc3ff'; ctx.font = '11px system-ui, sans-serif'; ctx.fillText(label.split('/').pop(), 6, 18);
+    ctx.fillStyle = '#9fc3ff';
+    ctx.font = '11px system-ui, sans-serif';
+    ctx.fillText(label.split('/').pop(), 6, 18);
     return false;
   }
 

--- a/js/piePreview.js
+++ b/js/piePreview.js
@@ -36,6 +36,7 @@ export async function renderPieIntoCanvas(canvas, piePath, options = {}) {
   }
   // Fallback placeholder
   const ctx = canvas.getContext('2d');
+  if (!ctx) return false;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   ctx.fillStyle = '#0b1220';
   ctx.fillRect(0, 0, canvas.width, canvas.height);


### PR DESCRIPTION
## Summary
- Gracefully handle PIE references that include a leading zero not present in asset filenames
- Avoid crashing mini viewer fallback when canvas context is unavailable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd93522454833385ccd5e55a802516