### PR TITLE
Handle PIE assets without subdirectories

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,8 @@ tr:hover td{ background:#0e141c; }
         return out;
       }
       filename = String(filename || '').toLowerCase();
+      // PIE assets live directly under /pies; strip any path components.
+      filename = filename.replace(/^.*[\\\/]/, '');
       const url = `pies/${filename}`;
       try {
         const res = await fetch(url, { method: 'HEAD' });


### PR DESCRIPTION
## Summary
- Strip directory paths from PIE filenames so assets are loaded only from `/pies`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd967448448333a12a0dd781341e6e