### PR TITLE
Fix weapon model placement over base structures

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,26 +131,28 @@ tr:hover td{ background:#0e141c; }
         for (const f of filename) out.push(await resolvePieUrl(f));
         return out;
       }
-      filename = String(filename || '').toLowerCase();
+      const orig = String(filename || '');
+      const lower = orig.toLowerCase();
+      const isWeapon = /components\/weapons\//.test(lower);
       // PIE assets live directly under /pies; strip any path components.
-      filename = filename.replace(/^.*[\\\/]/, '');
-      const url = `pies/${filename}`;
+      let name = lower.replace(/^.*[\\\/]/, '');
+      const baseUrl = `pies/${name}`;
       try {
-        const res = await fetch(url, { method: 'HEAD' });
-        if (res.ok) return url;
+        const res = await fetch(baseUrl, { method: 'HEAD' });
+        if (res.ok) return isWeapon ? `${baseUrl}#weapon` : baseUrl;
       } catch (_) {}
       // some stats reference PIE files with a leading zero that is
       // not present in the assets directory. Try stripping leading
       // zeroes and look for a matching file.
-      const alt = filename.replace(/^0+/, '');
-      if (alt !== filename) {
-        const altUrl = `pies/${alt}`;
+      const alt = name.replace(/^0+/, '');
+      if (alt !== name) {
+        const altBase = `pies/${alt}`;
         try {
-          const res2 = await fetch(altUrl, { method: 'HEAD' });
-          if (res2.ok) return altUrl;
+          const res2 = await fetch(altBase, { method: 'HEAD' });
+          if (res2.ok) return isWeapon ? `${altBase}#weapon` : altBase;
         } catch (_) {}
       }
-      return filename;
+      return isWeapon ? `${name}#weapon` : name;
     }
   async function renderPieToCanvas(canvas, pieFile){
     const files = Array.isArray(pieFile) ? pieFile : [pieFile];

--- a/js/pie-loader.js
+++ b/js/pie-loader.js
@@ -122,7 +122,7 @@ async function render(canvas, url, options={}){
       // first geometry acts as the base; remember its bounding box so
       // subsequent pieces can be positioned relative to it
       baseBox = geometry.boundingBox.clone();
-    } else if (geomUrl && /components\/weapons\//i.test(geomUrl)) {
+    } else if (geomUrl && (/components\/weapons\//i.test(geomUrl) || /#weapon\b/i.test(geomUrl))) {
       // Weapon models are authored with their origin at ground level.
       // When rendering a structure + weapon combo, push weapon geometry
       // upwards so its bottom sits on top of the base model.


### PR DESCRIPTION
## Summary
- Preserve weapon path info when resolving PIE URLs
- Offset weapon geometries marked with `#weapon` to sit atop base structures

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bd97dd845c83339bd7faa1ec6bd4f5