### PR TITLE
Adjust PIE preview popup size and position

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@ tr:hover td{ background:#0e141c; }
 
 /* PIE preview popup */
 .pie-link{ cursor:pointer; color:var(--accent); }
-#piePopup{ position:fixed; top:5%; left:5%; width:90vw; height:90vh; margin:0; background:#0a0f14; border:1px solid var(--border); border-radius:8px; z-index:100; }
+#piePopup{ position:fixed; top:5%; right:5%; width:40vw; height:40vh; margin:0; background:#0a0f14; border:1px solid var(--border); border-radius:8px; z-index:100; }
 #piePopup.hidden{ display:none; }
 #piePopup canvas{ width:100%; height:100%; display:block; }
 #piePopup button{ position:absolute; top:4px; right:4px; background:none; border:none; color:var(--fg); cursor:pointer; }


### PR DESCRIPTION
## Summary
- shrink PIE preview popup to 40% width and height
- reposition preview popup to top-right corner

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bda13b5cdc833385953ab474e5b8e4