### PR TITLE
Fix null sensor causing extra sensor models

### DIFF
--- a/stats/sensor.json
+++ b/stats/sensor.json
@@ -191,11 +191,9 @@
 	"ZNULLSENSOR": {
 		"id": "ZNULLSENSOR",
 		"location": "DEFAULT",
-		"mountModel": "trlsnsr1.PIE",
-		"name": "Z NULL SENSOR",
-		"power": 500,
-		"range": 1024,
-		"sensorModel": "gnlsnsr1.PIE",
-		"type": "STANDARD"
-	}
+                "name": "Z NULL SENSOR",
+                "power": 500,
+                "range": 1024,
+                "type": "STANDARD"
+        }
 }


### PR DESCRIPTION
## Summary
- remove mount and sensor models from ZNULLSENSOR so structures like tank traps don't show a sensor

## Testing
- `node -e "fs=require('fs'); JSON.parse(fs.readFileSync('stats/sensor.json','utf8')); console.log('ok');"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcbce45d8833383c9d03410b9e021