### PR TITLE
Fix missing three.js module export

### DIFF
--- a/js/three.module.js
+++ b/js/three.module.js
@@ -1,0 +1,1 @@
+export * from './three.core.js';


### PR DESCRIPTION
## Summary
- add `js/three.module.js` re-export shim so `three.js` modules resolve in browser

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bde6f6238c833397949c01cbdac958