### PR TITLE
Fix missing three.js core by using CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,8 @@ tr:hover td{ background:#0e141c; }
   <canvas width="400" height="400"></canvas>
 </div>
 <script type="module">
-  import "./js/three.module.js";
+  import * as THREE from "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js";
+  window.THREE = THREE;
   import "./js/pie.js";
   import "./js/piePreview.js";
   import "./js/piePreview-init.js";

--- a/js/pie-mini-viewer.js
+++ b/js/pie-mini-viewer.js
@@ -1,5 +1,5 @@
 // pie-mini-viewer.js — render tiny PIE thumbnails into given container
-import * as THREE from "./three.module.js";
+import * as THREE from "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js";
 import { parsePie } from "./pie.js";
 
 // Some environments fail to provide shader precision info, returning `null`.


### PR DESCRIPTION
## Summary
- Load three.js from a CDN and expose it globally to avoid missing `three.core.js`
- Update PIE mini viewer to import three.js from the same CDN

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bde9e2f3688333aeda850607e2f43a