### PR TITLE
Fix missing three.js import in pie loader

### DIFF
--- a/js/pie-loader.js
+++ b/js/pie-loader.js
@@ -1,4 +1,4 @@
-import * as THREE from './three.module.js';
+import * as THREE from "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js";
 import { resolveTextureUrl } from './pie.js';
 
 // Ensure getShaderPrecisionFormat never returns null


### PR DESCRIPTION
## Summary
- Load three.js for PIE rendering from jsDelivr CDN instead of a missing local file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdec1307a08333ac1d22072aaf51f5