### PR TITLE
Add combined build cost metrics for hardpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Wz2100-mod-viewer
-test
+
+A lightweight web viewer for Warzone 2100 modding data. It reads the game's JSON stats and renders PIE models directly in the browser.
+
+## Features
+
+- Browse structures and weapons from the base game or uploaded stats.
+- Preview PIE models, automatically stacking hard-point bases with their mounted weapons.
+- Display build costs for both structures and their weapons, along with combined totals.
+
+Open `index.html` in a modern browser to explore the data.

--- a/index.html
+++ b/index.html
@@ -295,10 +295,37 @@ tr:hover td{ background:#0e141c; }
   const sensorMap = new Map();
   (normalizeRows(BOOTSTRAP.sensors, 'sensors') || []).forEach(s => { const id = (s && s.id !== undefined) ? String(s.id) : null; if (id) sensorMap.set(id, s); });
   const baseline = { structures: normalizeRows(BOOTSTRAP.baseline && BOOTSTRAP.baseline.structures, 'structures'), weapons: normalizeRows(BOOTSTRAP.baseline && BOOTSTRAP.baseline.weapons, 'weapons') };
+
+  const baselineWeaponMap = new Map();
+  (baseline.weapons || []).forEach(w => { const id = (w && w.id !== undefined) ? String(w.id) : null; if (id) baselineWeaponMap.set(id, w); });
+
+  function augmentStructureTotals(rows, map){
+    rows.forEach(r => {
+      const basePoints = Number(r.buildPoints) || 0;
+      const basePower = Number(r.buildPower) || 0;
+      let weaponPoints = 0, weaponPower = 0;
+      const ids = Array.isArray(r.weapons) ? r.weapons : (r.weapons !== undefined ? [r.weapons] : []);
+      ids.forEach(id => {
+        const w = map.get(String(id));
+        if (w){
+          weaponPoints += Number(w.buildPoints) || 0;
+          weaponPower += Number(w.buildPower) || 0;
+        }
+      });
+      r.weaponBuildPoints = weaponPoints;
+      r.weaponBuildPower = weaponPower;
+      r.totalBuildPoints = basePoints + weaponPoints;
+      r.totalBuildPower = basePower + weaponPower;
+    });
+  }
+
+  augmentStructureTotals(tabs.structures, weaponMap);
+  augmentStructureTotals(baseline.structures, baselineWeaponMap);
+
   const diffs = { structures: diffRows(tabs.structures, baseline.structures), weapons: diffRows(tabs.weapons, baseline.weapons) };
 
   const preferCols = {
-    structures: ['id','name','type','buildPoints','hitpoints','armour','thermal','strength','buildPower','weapons','longrange','damage'],
+    structures: ['id','name','type','buildPoints','weaponBuildPoints','totalBuildPoints','buildPower','weaponBuildPower','totalBuildPower','hitpoints','armour','thermal','strength','weapons','longrange','damage'],
     weapons: ['id','name','Damage','Range','ReloadTime','Class','model','baseModel']
   };
 
@@ -352,7 +379,7 @@ tr:hover td{ background:#0e141c; }
   }
 
   const USER_DEFAULTS_KEY = 'wzStatsUserDefaultCols_v1'; let userDefaultCols = {}; try { const u = localStorage.getItem(USER_DEFAULTS_KEY); if (u) userDefaultCols = JSON.parse(u) || {}; } catch(e){}
-  const defaultCols = { structures: ['name','type','buildpoints','hitpoints','armour','thermal','strength','damage','longrange','buildpower'], weapons: ['name','buildpoints','buildpower','damage','hitpoints','longrange','reloadtime','weaponclass'] };
+  const defaultCols = { structures: ['name','type','buildpoints','weaponbuildpoints','totalbuildpoints','hitpoints','armour','thermal','strength','damage','longrange','buildpower','weaponbuildpower','totalbuildpower'], weapons: ['name','buildpoints','buildpower','damage','hitpoints','longrange','reloadtime','weaponclass'] };
   function getDefaultCols(){ const all = currentAllCols(); const user = userDefaultCols[activeTab]; const wanted = (Array.isArray(user) && user.length ? user : (defaultCols[activeTab] || all)); return wanted.filter(c => all.includes(c)); }
 
   function getRaw(row, label){


### PR DESCRIPTION
## Summary
- calculate weapon and total build costs for each structure
- surface base, weapon, and combined build metrics in the structures table
- document viewer capabilities and cost display in README

## Testing
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bdef4cbc5c8333904043a9433a610e