### PR TITLE
Fix weapon stacking on structures in viewer

### DIFF
--- a/js/pie-loader.js
+++ b/js/pie-loader.js
@@ -166,18 +166,30 @@ async function render(canvas, url, options={}){
       // Weapon components are positioned using connector data when available;
       // fall back to stacking behavior otherwise.
       const baseY = baseTop != null ? baseTop : 0;
+      let tx = 0, ty = 0, tz = 0;
       if (geometry.userData && Array.isArray(geometry.userData.connectors) && geometry.userData.connectors.length) {
         const [cx = 0, cy = 0, cz = 0] = geometry.userData.connectors[0];
         if (baseWeaponConnector) {
           const [bcx = 0, bcy = baseY, bcz = 0] = baseWeaponConnector;
-          geometry.translate(bcx - cx, bcy - cy, bcz - cz);
+          tx = bcx - cx;
+          ty = bcy - cy;
+          tz = bcz - cz;
         } else {
-          geometry.translate(-cx, baseY - cy, -cz);
+          tx = -cx;
+          ty = baseY - cy;
+          tz = -cz;
         }
       } else {
         const refY = weaponTop != null ? weaponTop : baseY;
         const offset = refY - geometry.boundingBox.min.y;
-        geometry.translate(0, offset, 0);
+        tx = 0; ty = offset; tz = 0;
+      }
+      geometry.translate(tx, ty, tz);
+      if (geometry.userData && Array.isArray(geometry.userData.connectors)) {
+        geometry.userData.connectors = geometry.userData.connectors.map(([x = 0, y = 0, z = 0]) => [x + tx, y + ty, z + tz]);
+        baseWeaponConnector = geometry.userData.connectors[0];
+      } else {
+        baseWeaponConnector = null;
       }
       geometry.computeBoundingBox();
       weaponTop = geometry.boundingBox.max.y;


### PR DESCRIPTION
## Summary
- Correct weapon stacking so structure weapons attach via mount connectors
- Update PIE loader to translate connectors and chain weapon mounts

## Testing
- `node --check js/pie-loader.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdf96103a88333b6ef0011f3922288