### PR TITLE
Add tower preview with placeholder boxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,7 @@ tr:hover td{ background:#0e141c; }
         return out;
       }
       const orig = String(filename || '');
+      if (orig.startsWith('__')) return orig;
       const lower = orig.toLowerCase();
       const isWeapon = /components\/weapons\//.test(lower);
       // PIE assets live directly under /pies; strip any path components.
@@ -389,10 +390,10 @@ tr:hover td{ background:#0e141c; }
   }
   function getOldRaw(row, label){ if (!row || !row.__old) return undefined; const list = (columnLookup[label] || [label]); for (const key of list){ if (Object.prototype.hasOwnProperty.call(row.__old, key)) return row.__old[key]; } return row.__old[label]; }
 
-  // Extract pie filenames from common fields on a row and referenced weapons
+  // Extract pie filenames for previews. Towers with weapons get simple box
+  // placeholders stacked beneath the weapon model to visualize the structure.
   function extractPieNames(row){
     if (!row || typeof row !== 'object') return [];
-    const fields = ['baseModel','basemodel','structureModel','structuremodel','model','modelFile','weaponsModel','turretModel'];
     const out = [];
     const add = (s, prefix) => {
       if (!s) return;
@@ -407,6 +408,24 @@ tr:hover td{ background:#0e141c; }
         if (!out.includes(full)) out.push(full);
       }
     };
+
+    // If the structure references weapons, build a tower preview using
+    // placeholder boxes and the weapon's model on top.
+    const weaponIds = row.weapons;
+    const list = Array.isArray(weaponIds) ? weaponIds : (weaponIds !== undefined ? [weaponIds] : []);
+    if (list.length) {
+      out.push('__primaryBox');
+      out.push('__weaponBox#weapon');
+      list.forEach(id => {
+        if (id == null) return;
+        const w = weaponMap.get(String(id));
+        if (!w) return;
+        ['model','barrelModel','turretModel'].forEach(f => add(w[f], 'components/weapons/'));
+      });
+      return out;
+    }
+
+    const fields = ['baseModel','basemodel','structureModel','structuremodel','model','modelFile','weaponsModel','turretModel'];
     for (const f of fields){
       if (row[f] === undefined) continue;
       const v = row[f];
@@ -426,16 +445,6 @@ tr:hover td{ background:#0e141c; }
         });
       }
     }
-    // include weapon models referenced by structures
-    const weaponIds = row.weapons;
-    const list = Array.isArray(weaponIds) ? weaponIds : (weaponIds !== undefined ? [weaponIds] : []);
-    list.forEach(id => {
-      if (id == null) return;
-      const w = weaponMap.get(String(id));
-      if (!w) return;
-      // ensure base/mount models load before weapon model so weapons sit atop mounts
-      ['mountModel','baseModel','basemodel','model','barrelModel','turretModel'].forEach(f => add(w[f], 'components/weapons/'));
-    });
     return out;
   }
 

--- a/js/pie-loader.js
+++ b/js/pie-loader.js
@@ -98,6 +98,23 @@ async function loadPieGeometry(url){
   return parsePieGeometry(text);
 }
 
+function createBoxGeometry(size){
+  const s = Array.isArray(size) ? size : [size, size, size];
+  const geo = new THREE.BoxGeometry(s[0], s[1], s[2]);
+  geo.computeBoundingBox();
+  return geo;
+}
+
+async function loadGeometry(url){
+  if (url === '__primaryBox') {
+    return createBoxGeometry([40, 30, 40]);
+  }
+  if (url === '__weaponBox#weapon' || url === '__weaponBox') {
+    return createBoxGeometry([20, 20, 20]);
+  }
+  return await loadPieGeometry(url);
+}
+
 async function render(canvas, url, options={}){
   if(!isWebGLAvailable()){
     console.error('WebGL not supported in this environment.');
@@ -115,7 +132,7 @@ async function render(canvas, url, options={}){
   for (const u of urls){
     // keep track of source url alongside loaded geometry so we can apply
     // special positioning rules based on where the model comes from
-    const g = await loadPieGeometry(u);
+    const g = await loadGeometry(u);
     geometries.push({ geometry: g, url: u });
   }
   // Ensure base pieces are processed before any special (#weapon, #stack)


### PR DESCRIPTION
## Summary
- render towers by stacking placeholder boxes and weapon models
- support special box geometry tokens in PIE loader
- skip resolution for generated geometries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be1b0ce7448333aa559870435f14b5