### PR TITLE
Use real structure and weapon models

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,21 +409,8 @@ tr:hover td{ background:#0e141c; }
       }
     };
 
-    // If the structure references weapons, build a tower preview using
-    // placeholder boxes and the weapon's model on top.
     const weaponIds = row.weapons;
     const list = Array.isArray(weaponIds) ? weaponIds : (weaponIds !== undefined ? [weaponIds] : []);
-    if (list.length) {
-      out.push('__primaryBox');
-      out.push('__weaponBox#weapon');
-      list.forEach(id => {
-        if (id == null) return;
-        const w = weaponMap.get(String(id));
-        if (!w) return;
-        ['model','barrelModel','turretModel'].forEach(f => add(w[f], 'components/weapons/'));
-      });
-      return out;
-    }
 
     const fields = ['baseModel','basemodel','structureModel','structuremodel','model','modelFile','weaponsModel','turretModel'];
     for (const f of fields){
@@ -435,6 +422,17 @@ tr:hover td{ background:#0e141c; }
         catch(e){ add(v); }
       } else { add(v); }
     }
+
+    list.forEach(id => {
+      if (id == null) return;
+      const w = weaponMap.get(String(id));
+      if (!w) return;
+      if (w.mountModel) add(String(w.mountModel) + '#weapon', 'components/weapons/');
+      ['model','barrelModel','turretModel'].forEach(f => {
+        if (w[f]) add(String(w[f]) + '#weapon', 'components/weapons/');
+      });
+    });
+
     // include sensor models referenced by structures
     const sensorId = row.sensorID || row.sensorid;
     if (sensorId != null) {

--- a/js/pie-loader.js
+++ b/js/pie-loader.js
@@ -98,20 +98,7 @@ async function loadPieGeometry(url){
   return parsePieGeometry(text);
 }
 
-function createBoxGeometry(size){
-  const s = Array.isArray(size) ? size : [size, size, size];
-  const geo = new THREE.BoxGeometry(s[0], s[1], s[2]);
-  geo.computeBoundingBox();
-  return geo;
-}
-
 async function loadGeometry(url){
-  if (url === '__primaryBox') {
-    return createBoxGeometry([40, 30, 40]);
-  }
-  if (url === '__weaponBox#weapon' || url === '__weaponBox') {
-    return createBoxGeometry([20, 20, 20]);
-  }
   return await loadPieGeometry(url);
 }
 


### PR DESCRIPTION
## Summary
- Replace placeholder boxes in structure previews with actual structure models and weapon mount models.
- Simplify PIE loader by removing unused placeholder box geometry handling.

## Testing
- `node --check js/pie-loader.js`
- `npx htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be213eafec8333a8b5a1d5346c185c